### PR TITLE
kernel: fix ccache variable sanitation for clang builds

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -257,7 +257,9 @@ endif
 
 ifeq ($(TARGET_KERNEL_CLANG_COMPILE),true)
     KERNEL_CROSS_COMPILE := CROSS_COMPILE="$(KERNEL_TOOLCHAIN_PATH)"
-    KERNEL_CC ?= CC="$(ccache) $(TARGET_KERNEL_CLANG_PATH)/clang"
+    ifeq ($(KERNEL_CC),)
+        KERNEL_CC := CC="$(ccache) $(TARGET_KERNEL_CLANG_PATH)/clang"
+    endif
 else
     KERNEL_CROSS_COMPILE := CROSS_COMPILE="$(ccache) $(KERNEL_TOOLCHAIN_PATH)"
 endif


### PR DESCRIPTION
* When using "?=", expansion doesn't happen right away, so the ccache
  variable is sanitized before KERNEL_CC gets expanded and no ccache
  is ever used for clang builds.

* With ":=", expansion happens immediately. So let's manually check
  if KERNEL_CC is already set somewhere else to determine whether or
  not we should set it ourselves using ":=".

Change-Id: I8a61767606a4f3d4c6ba88c68b10fd2e11783406