### PR TITLE
lineage: Unconditionally ship exFAT tools

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -196,15 +196,10 @@ PRODUCT_PACKAGES += \
     libhealthd.lineage
 endif
 
-# ExFAT support
-WITH_EXFAT ?= true
-ifeq ($(WITH_EXFAT),true)
-TARGET_USES_EXFAT := true
+# exFAT tools
 PRODUCT_PACKAGES += \
-    mount.exfat \
     fsck.exfat \
     mkfs.exfat
-endif
 
 # Openssh
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
 * We no longer need to build the mount.exfat tool because
   only kernel implementations will be supported from now on.

Change-Id: Ic7e1354e6ead6a96a9d6021de8dac4cfdabcbbce